### PR TITLE
feat(web): add responsive tournaments page

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -23,10 +24,39 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="fr">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <header className="border-b">
+          <nav className="container mx-auto flex flex-wrap items-center justify-between p-4">
+            <Link href="/" className="font-bold text-lg">
+              PadelPyrenees
+            </Link>
+            <ul className="flex flex-wrap gap-4 text-sm">
+              <li>
+                <Link href="/classement" className="hover:text-blue-600">
+                  Classement
+                </Link>
+              </li>
+              <li>
+                <Link href="/matchmaking" className="hover:text-blue-600">
+                  Matchmaking
+                </Link>
+              </li>
+              <li>
+                <Link href="/reservations" className="hover:text-blue-600">
+                  Réservations
+                </Link>
+              </li>
+              <li>
+                <Link href="/tournois" className="hover:text-blue-600">
+                  Tournois
+                </Link>
+              </li>
+            </ul>
+          </nav>
+        </header>
         {children}
       </body>
     </html>

--- a/apps/web/src/app/tournois/page.tsx
+++ b/apps/web/src/app/tournois/page.tsx
@@ -1,0 +1,104 @@
+import TournamentCard, { Tournament } from "@/components/TournamentCard";
+
+const tournaments: Tournament[] = [
+  {
+    id: 1,
+    title: "Tournoi Mixte Halloween",
+    image: "https://images.unsplash.com/photo-1603279091656-1433c0af5004?auto=format&fit=crop&w=800&q=60",
+    type: "Mixte",
+    status: "Inscription ouverte",
+    date: "24 oct. - 27 oct. 2024",
+    level: "Niveau 3",
+    participants: "32 participants",
+    price: "20€ / joueur",
+    reward: "500€ + Trophée",
+  },
+  {
+    id: 2,
+    title: "Championnat d'Automne",
+    image: "https://images.unsplash.com/photo-1598974578018-9d1d7d6f928d?auto=format&fit=crop&w=800&q=60",
+    type: "Individuel",
+    status: "Inscription ouverte",
+    date: "12 nov. - 15 nov. 2024",
+    level: "Niveau 4",
+    participants: "24 participants",
+    price: "30€ / joueur",
+    reward: "300€ + Trophée",
+  },
+  {
+    id: 3,
+    title: "Open des Débutants",
+    image: "https://images.unsplash.com/photo-1521412644187-c49fa049e84d?auto=format&fit=crop&w=800&q=60",
+    type: "Débutant",
+    status: "Complet",
+    date: "29 nov. - 3 déc. 2024",
+    level: "Niveau 1",
+    participants: "16 participants",
+    price: "10€ / joueur",
+    reward: "Lots",
+  },
+  {
+    id: 4,
+    title: "Corporate Challenge",
+    image: "https://images.unsplash.com/photo-1508606572321-901ea4437071?auto=format&fit=crop&w=800&q=60",
+    type: "Entreprise",
+    status: "Inscription ouverte",
+    date: "25 nov. 2024",
+    level: "Tous niveaux",
+    participants: "40 participants",
+    price: "Gratuit",
+    reward: "Trophée",
+  },
+];
+
+export default function TournoisPage() {
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-2">Tournois</h1>
+      <p className="text-gray-600 mb-6">
+        Participez aux tournois et compétitions de padel
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+        <div className="text-center p-4 border rounded-lg">
+          <p className="text-2xl font-bold">6</p>
+          <p className="text-sm text-gray-600">Tournois</p>
+        </div>
+        <div className="text-center p-4 border rounded-lg">
+          <p className="text-2xl font-bold">2</p>
+          <p className="text-sm text-gray-600">Inscription ouverte</p>
+        </div>
+        <div className="text-center p-4 border rounded-lg">
+          <p className="text-2xl font-bold">1</p>
+          <p className="text-sm text-gray-600">En cours</p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-4 mb-8">
+        <div className="flex flex-wrap gap-2">
+          <button className="px-3 py-1 rounded-full border text-sm">
+            Inscriptions ouvertes
+          </button>
+          <button className="px-3 py-1 rounded-full border text-sm">
+            Inscriptions fermées
+          </button>
+          <button className="px-3 py-1 rounded-full border text-sm">Niveau</button>
+          <button className="px-3 py-1 rounded-full border text-sm">Date</button>
+        </div>
+        <div className="flex gap-2">
+          <button className="px-3 py-1 rounded-full border text-sm">Carte</button>
+          <button className="px-3 py-1 rounded-full bg-blue-600 text-white text-sm">
+            Organiser un tournoi
+          </button>
+        </div>
+      </div>
+
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {tournaments.map((t) => (
+          <TournamentCard key={t.id} tournament={t} />
+        ))}
+      </div>
+    </main>
+  );
+}
+

--- a/apps/web/src/components/TournamentCard.tsx
+++ b/apps/web/src/components/TournamentCard.tsx
@@ -1,0 +1,56 @@
+import Image from "next/image";
+
+export interface Tournament {
+  id: number;
+  title: string;
+  image: string;
+  type: string;
+  status: string;
+  date: string;
+  level: string;
+  participants: string;
+  price: string;
+  reward: string;
+}
+
+export default function TournamentCard({ tournament }: { tournament: Tournament }) {
+  return (
+    <div className="flex flex-col bg-white rounded-xl shadow-sm overflow-hidden border border-gray-200">
+      <div className="relative">
+        <Image
+          src={tournament.image}
+          alt={tournament.title}
+          width={600}
+          height={160}
+          className="w-full h-40 object-cover"
+        />
+        <span className="absolute top-2 left-2 bg-green-500 text-white text-xs font-medium px-2 py-1 rounded">
+          {tournament.status}
+        </span>
+        <span className="absolute top-2 right-2 bg-white/90 text-gray-700 text-xs font-medium px-2 py-1 rounded">
+          {tournament.type}
+        </span>
+      </div>
+      <div className="flex flex-col gap-2 p-4 flex-grow">
+        <h3 className="font-semibold text-lg">{tournament.title}</h3>
+        <p className="text-sm text-gray-600">{tournament.participants}</p>
+        <p className="text-sm text-gray-600">{tournament.level}</p>
+        <p className="text-sm text-gray-600">{tournament.date}</p>
+        <div className="mt-auto">
+          <div className="flex justify-between items-center text-sm text-gray-700 mb-4">
+            <span>{tournament.price}</span>
+            <span>{tournament.reward}</span>
+          </div>
+          <div className="flex gap-2">
+            <button className="flex-1 bg-gray-100 hover:bg-gray-200 text-gray-800 text-sm py-2 rounded">
+              Détails
+            </button>
+            <button className="flex-1 bg-blue-600 hover:bg-blue-700 text-white text-sm py-2 rounded">
+              S&apos;inscrire
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add navigation header and tournaments route
- display tournament cards with stats and filters
- configure remote image support for Unsplash

## Testing
- `pnpm --filter web lint`


------
https://chatgpt.com/codex/tasks/task_e_68a638c0b794832aa0fe09423d787801