### PR TITLE
fix(api): add typings for middleware and stripe checkout

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,6 +21,7 @@
     "zod": "^4.0.17"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/node": "^24.2.1",
     "prisma": "^6.13.0",

--- a/apps/api/src/middlewares/authGuard.ts
+++ b/apps/api/src/middlewares/authGuard.ts
@@ -1,5 +1,6 @@
 import { getAuth } from "firebase-admin/auth";
 import admin from "firebase-admin";
+import { Request, Response, NextFunction } from "express";
 
 if (!admin.apps.length) {
   admin.initializeApp({
@@ -11,7 +12,11 @@ if (!admin.apps.length) {
   });
 }
 
-export async function authGuard(req, res, next) {
+export async function authGuard(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
   const auth = req.headers.authorization;
   if (!auth?.startsWith("Bearer ")) return res.status(401).send("No token");
   try {

--- a/apps/api/src/services/adaptaters/payments/stripe.ts
+++ b/apps/api/src/services/adaptaters/payments/stripe.ts
@@ -1,12 +1,34 @@
 import Stripe from "stripe";
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: "2024-06-20" });
 
-export async function createCheckoutSession({ amount, currency="eur", successUrl, cancelUrl }) {
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+
+interface CheckoutParams {
+  amount: number;
+  currency?: string;
+  successUrl: string;
+  cancelUrl: string;
+}
+
+export async function createCheckoutSession({
+  amount,
+  currency = "eur",
+  successUrl,
+  cancelUrl,
+}: CheckoutParams) {
   const session = await stripe.checkout.sessions.create({
     mode: "payment",
-    line_items: [{ price_data: { currency, product_data: { name: "Réservation court" }, unit_amount: amount }, quantity: 1 }],
+    line_items: [
+      {
+        price_data: {
+          currency,
+          product_data: { name: "Réservation court" },
+          unit_amount: amount,
+        },
+        quantity: 1,
+      },
+    ],
     success_url: successUrl,
-    cancel_url: cancelUrl
+    cancel_url: cancelUrl,
   });
   return session.url;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
         specifier: ^4.0.17
         version: 4.0.17
     devDependencies:
+      '@types/cors':
+        specifier: ^2.8.19
+        version: 2.8.19
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.3
@@ -1587,6 +1590,9 @@ packages:
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -7158,6 +7164,10 @@ snapshots:
     optional: true
 
   '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 24.2.1
+
+  '@types/cors@2.8.19':
     dependencies:
       '@types/node': 24.2.1
 


### PR DESCRIPTION
## Summary
- type express middleware and stripe checkout session parameters
- remove hardcoded Stripe API version
- add missing `@types/cors` dev dependency

## Testing
- `pnpm --filter api exec tsc --noEmit`
- `pnpm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a634bc9534832a91bce4bb626bbc28