### PR TITLE
fix: convert firebase private key newlines

### DIFF
--- a/apps/api/src/middlewares/authGuard.ts
+++ b/apps/api/src/middlewares/authGuard.ts
@@ -6,6 +6,7 @@ if (!admin.apps.length) {
     credential: admin.credential.cert({
       projectId: process.env.FIREBASE_PROJECT_ID,
       clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+      // Convert escaped newlines in the private key to real newlines
       privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n')
     })
   });


### PR DESCRIPTION
## Summary
- clarify firebase private key newline replacement

## Testing
- `pnpm test` *(fails: Error: no test specified)*
- `node` script to initialize firebase-admin with escaped newlines

------
https://chatgpt.com/codex/tasks/task_e_68a636948f9c832a848a24c1a787ea0d