### PR TITLE
feat(web): import tailwindcss in global styles

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,3 +1,4 @@
+@import "tailwindcss";
 @custom-variant dark (&:is(.dark *));
 
 :root {


### PR DESCRIPTION
## Summary
- import Tailwind CSS in global stylesheet to enable base, component, and utility layers

## Testing
- `pnpm lint --file src/app/globals.css` *(warning: file ignored; no matching configuration)*
- `pnpm test` (apps/web)
- `pnpm test` (root; fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68a9b384b0c4832a8d07df024333c5eb