### PR TITLE
feat(web): add my tournaments section

### DIFF
--- a/apps/web/src/app/tournois/page.tsx
+++ b/apps/web/src/app/tournois/page.tsx
@@ -15,6 +15,18 @@ import { Tournament, TournamentType, TournamentLevel, TournamentStatus, SortOpti
 export default function TournamentPage() {
   const [currentView, setCurrentView] = useState<'list' | 'detail'>('list');
   const [selectedTournament, setSelectedTournament] = useState<Tournament | null>(null);
+  const [registeredTournamentIds, setRegisteredTournamentIds] = useState<Set<string>>(new Set());
+  const [myFilter, setMyFilter] = useState<'upcoming' | 'completed'>('upcoming');
+
+  const myTournaments = useMemo(() => {
+    return mockTournaments.filter(t => registeredTournamentIds.has(t.id));
+  }, [registeredTournamentIds]);
+
+  const myFilteredTournaments = useMemo(() => {
+    return myTournaments.filter(t =>
+      myFilter === 'upcoming' ? t.status !== 'completed' : t.status === 'completed'
+    );
+  }, [myFilter, myTournaments]);
   
   // États pour les filtres
   const [searchQuery, setSearchQuery] = useState('');
@@ -26,7 +38,7 @@ export default function TournamentPage() {
 
   // Filtres et tri des tournois
   const filteredAndSortedTournaments = useMemo(() => {
-    let filtered = mockTournaments.filter(tournament => {
+    const filtered = mockTournaments.filter(tournament => {
       // Filtre par recherche
       const matchesSearch = 
         tournament.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -99,6 +111,11 @@ export default function TournamentPage() {
   const handleRegister = (tournament: Tournament) => {
     // Simulation d'inscription
     toast.success(`Inscription au tournoi "${tournament.title}" confirmée !`);
+    setRegisteredTournamentIds(prev => {
+      const newSet = new Set(prev);
+      newSet.add(tournament.id);
+      return newSet;
+    });
   };
 
   // Statistiques rapides
@@ -156,6 +173,49 @@ export default function TournamentPage() {
             <p className="text-sm text-muted-foreground">En cours</p>
           </CardContent>
         </Card>
+      </div>
+
+      {/* Mes Tournois */}
+      <div>
+        <h2 className="mb-4">🎾 Mes Tournois</h2>
+        <div className="flex gap-2 mb-4">
+          <Button
+            variant={myFilter === 'upcoming' ? 'default' : 'outline'}
+            onClick={() => setMyFilter('upcoming')}
+          >
+            ⏳ À venir
+          </Button>
+          <Button
+            variant={myFilter === 'completed' ? 'default' : 'outline'}
+            onClick={() => setMyFilter('completed')}
+          >
+            🏁 Terminé
+          </Button>
+        </div>
+
+        {myFilteredTournaments.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+            {myFilteredTournaments.map((tournament) => (
+              <TournamentCard
+                key={tournament.id}
+                tournament={tournament}
+                onViewDetails={handleViewDetails}
+                onRegister={handleRegister}
+              />
+            ))}
+          </div>
+        ) : (
+          <Card className="mb-8">
+            <CardContent className="p-12 text-center">
+              <Trophy className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+              <h3 className="mb-2">
+                {myFilter === 'upcoming'
+                  ? 'Vous êtes inscrit à aucun tournois à venir'
+                  : 'Vous êtes inscrit à aucun tournois passé'}
+              </h3>
+            </CardContent>
+          </Card>
+        )}
       </div>
 
       {/* Actions principales */}

--- a/apps/web/src/data/tournamentData.ts
+++ b/apps/web/src/data/tournamentData.ts
@@ -36,6 +36,24 @@ export const mockTournaments: Tournament[] = [
     maxParticipants: 24,
     entryFee: 30,
     prizes: { first: '500€', second: '250€', third: '100€' }
+  },
+  {
+    id: '3',
+    title: 'Championnat de Lyon',
+    description: 'Finale annuelle',
+    image: '/images/lyon.jpg',
+    type: 'doubles',
+    level: 'intermédiaire',
+    status: 'completed',
+    startDate: '2025-04-01',
+    endDate: '2025-04-02',
+    registrationDeadline: '2025-03-20',
+    location: { name: 'Club de Lyon', address: '789 Rue de Lyon', lat: 45.764, lng: 4.8357 },
+    organizer: { name: 'Lyon Padel', contact: 'contact@lyonpadel.fr' },
+    currentParticipants: 16,
+    maxParticipants: 16,
+    entryFee: 25,
+    prizes: { first: '300€', second: '150€', third: '75€' }
   }
 ];
 


### PR DESCRIPTION
## Summary
- track registered tournaments and allow switching between upcoming and completed views
- add "Mes Tournois" section with filter buttons and empty states
- include sample completed tournament data for testing

## Testing
- `pnpm --filter web lint --file src/app/tournois/page.tsx`
- `pnpm --filter web test`
- `pnpm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bf98d364832aa36545b930c3af71