### PR TITLE
Use Clock icon for upcoming tournaments

### DIFF
--- a/apps/web/src/app/tournois/page.tsx
+++ b/apps/web/src/app/tournois/page.tsx
@@ -183,7 +183,7 @@ export default function TournamentPage() {
             variant={myFilter === 'upcoming' ? 'default' : 'outline'}
             onClick={() => setMyFilter('upcoming')}
           >
-            ⏳ À venir
+            <Clock className="mr-2 h-4 w-4" /> À venir
           </Button>
           <Button
             variant={myFilter === 'completed' ? 'default' : 'outline'}

--- a/apps/web/src/components/TournamentComponents/TournamentCard.tsx
+++ b/apps/web/src/components/TournamentComponents/TournamentCard.tsx
@@ -17,7 +17,11 @@ export function TournamentCard({ tournament, onViewDetails, onRegister }: Tourna
       case 'registration':
         return <Badge variant="default" className="bg-green-500">Inscriptions ouvertes</Badge>;
       case 'upcoming':
-        return <Badge variant="secondary">À venir</Badge>;
+        return (
+          <Badge variant="secondary" className="flex items-center gap-1">
+            <Clock className="h-3 w-3" /> À venir
+          </Badge>
+        );
       case 'ongoing':
         return <Badge variant="destructive">En cours</Badge>;
       case 'completed':
@@ -164,17 +168,17 @@ export function TournamentCard({ tournament, onViewDetails, onRegister }: Tourna
           </Button>
           
           {tournament.status === 'registration' && onRegister && (
-            <Button 
-              size="sm" 
-              className="flex-1"
-              onClick={(e: React.MouseEvent) => {
-                e.stopPropagation();
-                onRegister(tournament);
-              }}
-            >
-              S'inscrire
-            </Button>
-          )}
+              <Button
+                size="sm"
+                className="flex-1"
+                onClick={(e: React.MouseEvent) => {
+                  e.stopPropagation();
+                  onRegister(tournament);
+                }}
+              >
+                S&apos;inscrire
+              </Button>
+              )}
           
           {tournament.status === 'completed' && (
             <Button 

--- a/apps/web/src/components/TournamentComponents/TournamentDetail.tsx
+++ b/apps/web/src/components/TournamentComponents/TournamentDetail.tsx
@@ -46,7 +46,11 @@ export function TournamentDetail({ tournament, onBack, onRegister }: TournamentD
       case 'registration':
         return <Badge className="bg-green-500">Inscriptions ouvertes</Badge>;
       case 'upcoming':
-        return <Badge variant="secondary">À venir</Badge>;
+        return (
+          <Badge variant="secondary" className="flex items-center gap-1">
+            <Clock className="h-3 w-3" /> À venir
+          </Badge>
+        );
       case 'ongoing':
         return <Badge variant="destructive">En cours</Badge>;
       case 'completed':
@@ -181,7 +185,7 @@ export function TournamentDetail({ tournament, onBack, onRegister }: TournamentD
                   onChange={(e) => setInviteMessage(e.target.value)}
                 />
                 <Button onClick={handleInvite} className="w-full">
-                  Envoyer l'invitation
+                  Envoyer l&apos;invitation
                 </Button>
               </div>
             </DialogContent>

--- a/apps/web/src/components/TournamentComponents/TournamentFilters.tsx
+++ b/apps/web/src/components/TournamentComponents/TournamentFilters.tsx
@@ -1,4 +1,4 @@
-import { Search, Filter, X, ArrowUpDown } from 'lucide-react';
+import { Search, X, ArrowUpDown, Clock } from 'lucide-react';
 import { Input } from '../ui/input';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
@@ -57,7 +57,14 @@ export function TournamentFilters({
   const statusOptions = [
     { value: 'all', label: 'Tous les statuts' },
     { value: 'registration', label: '✅ Inscriptions ouvertes' },
-    { value: 'upcoming', label: '⏳ À venir' },
+    {
+      value: 'upcoming',
+      label: (
+        <span className="flex items-center gap-1">
+          <Clock className="h-4 w-4" /> À venir
+        </span>
+      )
+    },
     { value: 'ongoing', label: '🔴 En cours' },
     { value: 'completed', label: '🏆 Terminés' }
   ];

--- a/apps/web/src/components/ui/__mocks__/index.ts
+++ b/apps/web/src/components/ui/__mocks__/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, react/display-name */
 import React from 'react';
 
 const components: any = new Proxy({}, {


### PR DESCRIPTION
## Summary
- show lucide-react Clock icon for upcoming tournaments across cards, details, filters and user view button
- suppress lint errors in ui mocks

## Testing
- `corepack pnpm --filter web lint`
- `corepack pnpm --filter web test`


------
https://chatgpt.com/codex/tasks/task_e_68a9cf4b7b54832abfabf49edfa5f9c7