### PR TITLE
Use hourglass icon for ongoing tournaments

### DIFF
--- a/apps/web/src/app/tournois/page.tsx
+++ b/apps/web/src/app/tournois/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo } from 'react';
-import { Plus, Trophy, Calendar, Users, MapPin, Clock } from 'lucide-react';
+import { Plus, Trophy, Calendar, Hourglass, MapPin, Clock } from 'lucide-react';
 import { Card, CardContent } from '../../components/ui/card';
 import { Button } from '../../components/ui/button';
 import { Badge } from '../../components/ui/badge';
@@ -168,7 +168,7 @@ export default function TournamentPage() {
         
         <Card>
           <CardContent className="p-4 text-center">
-            <Users className="h-8 w-8 mx-auto mb-2 text-orange-500" />
+            <Hourglass className="h-8 w-8 mx-auto mb-2 text-orange-500" />
             <p className="text-2xl">{stats.ongoing}</p>
             <p className="text-sm text-muted-foreground">En cours</p>
           </CardContent>

--- a/apps/web/src/components/TournamentComponents/TournamentCard.tsx
+++ b/apps/web/src/components/TournamentComponents/TournamentCard.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Calendar, MapPin, Users, Trophy, Clock, Euro } from 'lucide-react';
+import { Calendar, MapPin, Users, Trophy, Clock, Euro, Hourglass } from 'lucide-react';
 import { Card, CardContent, CardHeader } from '../ui/card';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
@@ -19,7 +19,11 @@ export function TournamentCard({ tournament, onViewDetails, onRegister }: Tourna
       case 'upcoming':
         return <Badge variant="secondary">À venir</Badge>;
       case 'ongoing':
-        return <Badge variant="destructive">En cours</Badge>;
+        return (
+          <Badge variant="destructive">
+            <Hourglass className="h-4 w-4" />
+          </Badge>
+        );
       case 'completed':
         return <Badge variant="outline">Terminé</Badge>;
       default:

--- a/apps/web/src/components/TournamentComponents/TournamentDetail.tsx
+++ b/apps/web/src/components/TournamentComponents/TournamentDetail.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Calendar, MapPin, Users, Trophy, Euro, Clock, Share2, UserPlus, Download, ArrowLeft } from 'lucide-react';
+import { Calendar, MapPin, Users, Trophy, Euro, Clock, Hourglass, Share2, UserPlus, Download, ArrowLeft } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
@@ -48,7 +48,11 @@ export function TournamentDetail({ tournament, onBack, onRegister }: TournamentD
       case 'upcoming':
         return <Badge variant="secondary">À venir</Badge>;
       case 'ongoing':
-        return <Badge variant="destructive">En cours</Badge>;
+        return (
+          <Badge variant="destructive">
+            <Hourglass className="h-4 w-4" />
+          </Badge>
+        );
       case 'completed':
         return <Badge variant="outline">Terminé</Badge>;
       default:

--- a/apps/web/src/components/TournamentComponents/TournamentFilters.tsx
+++ b/apps/web/src/components/TournamentComponents/TournamentFilters.tsx
@@ -58,7 +58,7 @@ export function TournamentFilters({
     { value: 'all', label: 'Tous les statuts' },
     { value: 'registration', label: '✅ Inscriptions ouvertes' },
     { value: 'upcoming', label: '⏳ À venir' },
-    { value: 'ongoing', label: '🔴 En cours' },
+    { value: 'ongoing', label: '⌛ En cours' },
     { value: 'completed', label: '🏆 Terminés' }
   ];
 


### PR DESCRIPTION
## Summary
- Replace user icon with hourglass on tournaments page stats
- Show hourglass badge for ongoing tournaments in cards and detail view
- Use hourglass emoji for ongoing filter option

## Testing
- `pnpm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cf53c5c0832aad9a453e1d9be233