### PR TITLE
feat(web): add ranking page

### DIFF
--- a/apps/web/src/app/classement/page.tsx
+++ b/apps/web/src/app/classement/page.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState, useMemo } from 'react';
+import { TopPlayersCards } from '../../components/RankingComponents/TopPlayersCards';
+import { RankingTable } from '../../components/RankingComponents/RankingTable';
+import { SearchAndFilters } from '../../components/RankingComponents/SearchAndFilters';
+import { Card, CardContent } from '../../components/ui/card';
+import { Avatar, AvatarImage, AvatarFallback } from '../../components/ui/avatar';
+import { Input } from '../../components/ui/input';
+import { PlayerWithHistory, FilterPeriod } from '../../types/player';
+import { mockPlayers } from '../../data/playerData';
+import { EloChart } from '../../components/RankingComponents/EloChart';
+import { getWinRate, getEvolutionIcon } from '../../components/RankingComponents/utils';
+
+export default function RankingPage() {
+  const currentUser: PlayerWithHistory = mockPlayers[0];
+
+  const topPlayers = useMemo(() => {
+    return [...mockPlayers].sort((a, b) => b.evolution - a.evolution);
+  }, []);
+
+  const [mySearch, setMySearch] = useState('');
+  const myRankPlayers = useMemo(() => {
+    return mockPlayers.filter(
+      (p) =>
+        p.category === currentUser.category &&
+        p.pseudo.toLowerCase().includes(mySearch.toLowerCase())
+    );
+  }, [mySearch, currentUser.category]);
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedGender, setSelectedGender] = useState('all');
+  const [selectedCategory, setSelectedCategory] = useState('all');
+  const [selectedPeriod, setSelectedPeriod] = useState<FilterPeriod>('7j');
+
+  const filteredPlayers = useMemo(() => {
+    return mockPlayers.filter((p) => {
+      const matchesGender = selectedGender === 'all' || p.gender === selectedGender;
+      const matchesCategory = selectedCategory === 'all' || p.category === selectedCategory;
+      const matchesSearch = p.pseudo.toLowerCase().includes(searchQuery.toLowerCase());
+      return matchesGender && matchesCategory && matchesSearch;
+    });
+  }, [searchQuery, selectedGender, selectedCategory]);
+
+  const hasActiveFilters =
+    searchQuery !== '' || selectedGender !== 'all' || selectedCategory !== 'all';
+
+  const handleClearFilters = () => {
+    setSearchQuery('');
+    setSelectedGender('all');
+    setSelectedCategory('all');
+  };
+
+  return (
+    <div className="space-y-12">
+      <h1 className="text-3xl font-bold mb-4">Classement</h1>
+
+      {/* Top 3 progression */}
+      <TopPlayersCards players={topPlayers} />
+
+      {/* User ranking */}
+      <section>
+        <h2 className="mb-4">Mon classement</h2>
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex items-center gap-4 mb-6">
+              <Avatar className="h-16 w-16">
+                <AvatarImage src={currentUser.avatar} alt={currentUser.pseudo} />
+                <AvatarFallback>{currentUser.pseudo.substring(0, 2).toUpperCase()}</AvatarFallback>
+              </Avatar>
+              <div>
+                <h3>{currentUser.pseudo}</h3>
+                <p className="text-sm text-muted-foreground">
+                  #{currentUser.rank} • {currentUser.category}
+                </p>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6 text-center">
+              <div>
+                <p className="text-sm text-muted-foreground">ELO</p>
+                <p className="text-2xl font-bold">{currentUser.eloPoints}</p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Évolution</p>
+                <div className="flex items-center justify-center gap-1">
+                  {getEvolutionIcon(currentUser.evolution, true)}
+                  <span
+                    className={`${
+                      currentUser.evolution > 0
+                        ? 'text-green-600'
+                        : currentUser.evolution < 0
+                        ? 'text-red-600'
+                        : 'text-muted-foreground'
+                    }`}
+                  >
+                    {currentUser.evolution > 0 ? '+' : ''}
+                    {currentUser.evolution}
+                  </span>
+                </div>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Ratio</p>
+                <p className="text-2xl font-bold">
+                  {getWinRate(currentUser.wins, currentUser.losses)}%
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {currentUser.wins}V - {currentUser.losses}D
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Rang</p>
+                <p className="text-2xl font-bold">#{currentUser.rank}</p>
+              </div>
+            </div>
+
+            {currentUser.history && <EloChart history={currentUser.history} />}
+          </CardContent>
+        </Card>
+      </section>
+
+      {/* Ranking by user's category */}
+      <section>
+        <h2 className="mb-4">Classement {currentUser.category}</h2>
+        <div className="mb-4">
+          <Input
+            placeholder="Rechercher un joueur..."
+            value={mySearch}
+            onChange={(e) => setMySearch(e.target.value)}
+          />
+        </div>
+        <RankingTable players={myRankPlayers} />
+      </section>
+
+      {/* General ranking */}
+      <section>
+        <h2 className="mb-4">Classement général</h2>
+        <SearchAndFilters
+          searchQuery={searchQuery}
+          onSearchChange={setSearchQuery}
+          selectedGender={selectedGender}
+          onGenderChange={setSelectedGender}
+          selectedCategory={selectedCategory}
+          onCategoryChange={setSelectedCategory}
+          selectedPeriod={selectedPeriod}
+          onPeriodChange={setSelectedPeriod}
+          onClearFilters={handleClearFilters}
+          hasActiveFilters={hasActiveFilters}
+        />
+        <RankingTable players={filteredPlayers} />
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/components/RankingComponents/EloChart.tsx
+++ b/apps/web/src/components/RankingComponents/EloChart.tsx
@@ -1,0 +1,30 @@
+interface EloChartProps {
+  history: { date: string; elo: number }[];
+}
+
+export function EloChart({ history }: EloChartProps) {
+  if (history.length === 0) return null;
+
+  const max = Math.max(...history.map((p) => p.elo));
+  const min = Math.min(...history.map((p) => p.elo));
+  const range = max - min || 1;
+  const points = history
+    .map((p, i) => {
+      const x = (i / (history.length - 1)) * 100;
+      const y = 100 - ((p.elo - min) / range) * 100;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <svg viewBox="0 0 100 100" className="w-full h-24">
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+        className="text-primary"
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/components/RankingComponents/RankingTable.tsx
+++ b/apps/web/src/components/RankingComponents/RankingTable.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table';
-import { Avatar, AvatarImage, AvatarFallback } from './ui/avatar';
-import { Badge } from './ui/badge';
-import { Button } from './ui/button';
-import { ArrowUpDown, ArrowUp, ArrowDown, TrendingUp, TrendingDown, Minus } from 'lucide-react';
-import { PlayerWithHistory, SortField, SortDirection } from '../types/player';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
+import { Avatar, AvatarImage, AvatarFallback } from '../ui/avatar';
+import { Badge } from '../ui/badge';
+import { Button } from '../ui/button';
+import { ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
+import { PlayerWithHistory, SortField, SortDirection } from '../../types/player';
+import { getWinRate, getEvolutionIcon } from './utils';
 
 interface RankingTableProps {
   players: PlayerWithHistory[];
@@ -67,20 +68,6 @@ export function RankingTable({ players }: RankingTableProps) {
     return sortDirection === 'asc' ? 
       <ArrowUp className="h-4 w-4" /> : 
       <ArrowDown className="h-4 w-4" />;
-  };
-
-  const getWinRate = (wins: number, losses: number) => {
-    const total = wins + losses;
-    return total > 0 ? Math.round((wins / total) * 100) : 0;
-  };
-
-  const getEvolutionIcon = (evolution: number) => {
-    if (evolution > 0) {
-      return <TrendingUp className="h-4 w-4 text-green-500" />;
-    } else if (evolution < 0) {
-      return <TrendingDown className="h-4 w-4 text-red-500" />;
-    }
-    return <Minus className="h-4 w-4 text-muted-foreground" />;
   };
 
   const getCategoryColor = (category: string) => {

--- a/apps/web/src/components/RankingComponents/SearchAndFilters.tsx
+++ b/apps/web/src/components/RankingComponents/SearchAndFilters.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
-import { Input } from './ui/input';
-import { Button } from './ui/button';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
-import { Badge } from './ui/badge';
+import { Input } from '../ui/input';
+import { Button } from '../ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { Badge } from '../ui/badge';
 import { Search, Filter, X } from 'lucide-react';
-import { FilterPeriod } from '../types/player';
+import { FilterPeriod } from '../../types/player';
 
 interface SearchAndFiltersProps {
   searchQuery: string;

--- a/apps/web/src/components/RankingComponents/TopPlayersCards.tsx
+++ b/apps/web/src/components/RankingComponents/TopPlayersCards.tsx
@@ -1,8 +1,9 @@
-import { Card, CardContent } from './ui/card';
-import { Avatar, AvatarImage, AvatarFallback } from './ui/avatar';
-import { Badge } from './ui/badge';
-import { Trophy, TrendingUp, TrendingDown } from 'lucide-react';
-import { PlayerWithHistory } from '../types/player';
+import { Card, CardContent } from '../ui/card';
+import { Avatar, AvatarImage, AvatarFallback } from '../ui/avatar';
+import { Badge } from '../ui/badge';
+import { Trophy } from 'lucide-react';
+import { PlayerWithHistory } from '../../types/player';
+import { getWinRate, getEvolutionIcon } from './utils';
 
 interface TopPlayersCardsProps {
   players: PlayerWithHistory[];
@@ -18,20 +19,6 @@ export function TopPlayersCards({ players }: TopPlayersCardsProps) {
       3: 'text-amber-600'
     };
     return <Trophy className={`h-5 w-5 ${colors[rank as keyof typeof colors]}`} />;
-  };
-
-  const getEvolutionIcon = (evolution: number) => {
-    if (evolution > 0) {
-      return <TrendingUp className="h-4 w-4 text-green-500" />;
-    } else if (evolution < 0) {
-      return <TrendingDown className="h-4 w-4 text-red-500" />;
-    }
-    return null;
-  };
-
-  const getWinRate = (wins: number, losses: number) => {
-    const total = wins + losses;
-    return total > 0 ? Math.round((wins / total) * 100) : 0;
   };
 
   return (

--- a/apps/web/src/components/RankingComponents/utils.tsx
+++ b/apps/web/src/components/RankingComponents/utils.tsx
@@ -1,0 +1,16 @@
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+
+export const getWinRate = (wins: number, losses: number) => {
+  const total = wins + losses;
+  return total > 0 ? Math.round((wins / total) * 100) : 0;
+};
+
+export const getEvolutionIcon = (evolution: number, showNeutral = false) => {
+  if (evolution > 0) {
+    return <TrendingUp className="h-4 w-4 text-green-500" />;
+  }
+  if (evolution < 0) {
+    return <TrendingDown className="h-4 w-4 text-red-500" />;
+  }
+  return showNeutral ? <Minus className="h-4 w-4 text-muted-foreground" /> : null;
+};

--- a/apps/web/src/data/playerData.ts
+++ b/apps/web/src/data/playerData.ts
@@ -1,0 +1,131 @@
+import { PlayerWithHistory } from '../types/player';
+
+export const mockPlayers: PlayerWithHistory[] = [
+  {
+    id: '1',
+    pseudo: 'Maxime',
+    avatar: '/avatars/maxime.png',
+    gender: 'Homme',
+    category: 'Intermédiaire',
+    rank: 1,
+    eloPoints: 1600,
+    evolution: 50,
+    wins: 30,
+    losses: 10,
+    history: [
+      { date: '2024-01-01', elo: 1400 },
+      { date: '2024-02-01', elo: 1450 },
+      { date: '2024-03-01', elo: 1500 },
+      { date: '2024-04-01', elo: 1550 },
+      { date: '2024-05-01', elo: 1600 }
+    ]
+  },
+  {
+    id: '2',
+    pseudo: 'Léa',
+    avatar: '/avatars/lea.png',
+    gender: 'Femme',
+    category: 'Intermédiaire',
+    rank: 2,
+    eloPoints: 1580,
+    evolution: 40,
+    wins: 28,
+    losses: 12
+  },
+  {
+    id: '3',
+    pseudo: 'Julien',
+    avatar: '/avatars/julien.png',
+    gender: 'Homme',
+    category: 'Intermédiaire',
+    rank: 3,
+    eloPoints: 1550,
+    evolution: 30,
+    wins: 25,
+    losses: 15
+  },
+  {
+    id: '4',
+    pseudo: 'Emma',
+    avatar: '/avatars/emma.png',
+    gender: 'Femme',
+    category: 'Débutant',
+    rank: 4,
+    eloPoints: 1200,
+    evolution: 25,
+    wins: 10,
+    losses: 5
+  },
+  {
+    id: '5',
+    pseudo: 'Lucas',
+    avatar: '/avatars/lucas.png',
+    gender: 'Homme',
+    category: 'Avancé',
+    rank: 5,
+    eloPoints: 1700,
+    evolution: 20,
+    wins: 40,
+    losses: 20
+  },
+  {
+    id: '6',
+    pseudo: 'Chloé',
+    avatar: '/avatars/chloe.png',
+    gender: 'Femme',
+    category: 'Intermédiaire',
+    rank: 6,
+    eloPoints: 1500,
+    evolution: 10,
+    wins: 20,
+    losses: 18
+  },
+  {
+    id: '7',
+    pseudo: 'Nicolas',
+    avatar: '/avatars/nicolas.png',
+    gender: 'Homme',
+    category: 'Expert',
+    rank: 7,
+    eloPoints: 1800,
+    evolution: -5,
+    wins: 50,
+    losses: 25
+  },
+  {
+    id: '8',
+    pseudo: 'Sophie',
+    avatar: '/avatars/sophie.png',
+    gender: 'Femme',
+    category: 'Débutant',
+    rank: 8,
+    eloPoints: 1150,
+    evolution: -10,
+    wins: 8,
+    losses: 12
+  },
+  {
+    id: '9',
+    pseudo: 'Antoine',
+    avatar: '/avatars/antoine.png',
+    gender: 'Homme',
+    category: 'Intermédiaire',
+    rank: 9,
+    eloPoints: 1480,
+    evolution: -20,
+    wins: 18,
+    losses: 22
+  },
+  {
+    id: '10',
+    pseudo: 'Marie',
+    avatar: '/avatars/marie.png',
+    gender: 'Femme',
+    category: 'Avancé',
+    rank: 10,
+    eloPoints: 1650,
+    evolution: -30,
+    wins: 35,
+    losses: 25
+  }
+];

--- a/apps/web/src/types/player.ts
+++ b/apps/web/src/types/player.ts
@@ -1,0 +1,23 @@
+export type FilterPeriod = '7j' | '1m' | '3m' | '6m' | '1an';
+
+export type SortField = 'rank' | 'pseudo' | 'eloPoints' | 'winRate';
+export type SortDirection = 'asc' | 'desc';
+
+export interface EloHistoryPoint {
+  date: string;
+  elo: number;
+}
+
+export interface PlayerWithHistory {
+  id: string;
+  pseudo: string;
+  avatar: string;
+  gender: string;
+  category: string;
+  rank: number;
+  eloPoints: number;
+  evolution: number;
+  wins: number;
+  losses: number;
+  history?: EloHistoryPoint[];
+}


### PR DESCRIPTION
## Summary
- add ranking page with top players, user stats and leaderboards
- share player utilities across ranking components to reduce duplication
- add mock player data and types

## Testing
- `pnpm lint` *(fails: react/no-unescaped-entities, parsing error, @next/next/no-img-element)*
- `pnpm test` *(fails: jest-environment-jsdom cannot be found)*
- `pnpm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ab51256740832a8a6741c4b2fffe1b