### PR TITLE
feat(web): add reusable PlayerAvatar component

### DIFF
--- a/apps/web/src/app/classement/page.tsx
+++ b/apps/web/src/app/classement/page.tsx
@@ -5,7 +5,7 @@ import { TopPlayersCards } from '../../components/RankingComponents/TopPlayersCa
 import { RankingTable } from '../../components/RankingComponents/RankingTable';
 import { SearchAndFilters } from '../../components/RankingComponents/SearchAndFilters';
 import { Card, CardContent } from '../../components/ui/card';
-import { Avatar, AvatarImage, AvatarFallback } from '../../components/ui/avatar';
+import { PlayerAvatar } from '../../components/PlayerAvatar';
 import { Input } from '../../components/ui/input';
 import { PlayerWithHistory, FilterPeriod } from '../../types/player';
 import { mockPlayers } from '../../data/playerData';
@@ -64,10 +64,12 @@ export default function RankingPage() {
         <Card>
           <CardContent className="p-6">
             <div className="flex items-center gap-4 mb-6">
-              <Avatar className="h-16 w-16">
-                <AvatarImage src={currentUser.avatar} alt={currentUser.pseudo} />
-                <AvatarFallback>{currentUser.pseudo.substring(0, 2).toUpperCase()}</AvatarFallback>
-              </Avatar>
+              <PlayerAvatar
+                src={currentUser.avatar}
+                alt={currentUser.pseudo}
+                name={currentUser.pseudo}
+                className="h-16 w-16"
+              />
               <div>
                 <h3>{currentUser.pseudo}</h3>
                 <p className="text-sm text-muted-foreground">

--- a/apps/web/src/components/PlayerAvatar.tsx
+++ b/apps/web/src/components/PlayerAvatar.tsx
@@ -1,0 +1,17 @@
+import { Avatar, AvatarImage, AvatarFallback } from './ui/avatar';
+import { ComponentProps } from 'react';
+
+interface PlayerAvatarProps extends ComponentProps<typeof Avatar> {
+  src?: string;
+  alt: string;
+  name: string;
+}
+
+export function PlayerAvatar({ src, alt, name, ...props }: PlayerAvatarProps) {
+  return (
+    <Avatar {...props}>
+      <AvatarImage src={src} alt={alt} />
+      <AvatarFallback>{name.substring(0, 2).toUpperCase()}</AvatarFallback>
+    </Avatar>
+  );
+}

--- a/apps/web/src/components/RankingComponents/RankingTable.tsx
+++ b/apps/web/src/components/RankingComponents/RankingTable.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
-import { Avatar, AvatarImage, AvatarFallback } from '../ui/avatar';
+import { PlayerAvatar } from '../PlayerAvatar';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
@@ -120,10 +120,12 @@ export function RankingTable({ players }: RankingTableProps) {
               
               <TableCell>
                 <div className="flex items-center gap-3">
-                  <Avatar className="h-10 w-10">
-                    <AvatarImage src={player.avatar} alt={player.pseudo} />
-                    <AvatarFallback>{player.pseudo.substring(0, 2).toUpperCase()}</AvatarFallback>
-                  </Avatar>
+                  <PlayerAvatar
+                    src={player.avatar}
+                    alt={player.pseudo}
+                    name={player.pseudo}
+                    className="h-10 w-10"
+                  />
                   <div>
                     <div>{player.pseudo}</div>
                     <div className="text-sm text-muted-foreground">{player.gender}</div>

--- a/apps/web/src/components/RankingComponents/TopPlayersCards.tsx
+++ b/apps/web/src/components/RankingComponents/TopPlayersCards.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent } from '../ui/card';
-import { Avatar, AvatarImage, AvatarFallback } from '../ui/avatar';
+import { PlayerAvatar } from '../PlayerAvatar';
 import { Badge } from '../ui/badge';
 import { Trophy } from 'lucide-react';
 import { PlayerWithHistory } from '../../types/player';
@@ -40,10 +40,12 @@ export function TopPlayersCards({ players }: TopPlayersCardsProps) {
             </div>
             
             <div className="flex flex-col items-center text-center">
-              <Avatar className="h-16 w-16 mb-3">
-                <AvatarImage src={player.avatar} alt={player.pseudo} />
-                <AvatarFallback>{player.pseudo.substring(0, 2).toUpperCase()}</AvatarFallback>
-              </Avatar>
+              <PlayerAvatar
+                src={player.avatar}
+                alt={player.pseudo}
+                name={player.pseudo}
+                className="h-16 w-16 mb-3"
+              />
               
               <h3 className="mb-1">{player.pseudo}</h3>
               <p className="text-2xl mb-2">{player.eloPoints}</p>


### PR DESCRIPTION
## Summary
- create `PlayerAvatar` wrapper around Avatar primitives
- use `PlayerAvatar` across ranking components and page to remove duplicated JSX

## Testing
- `pnpm --filter web test`
- `pnpm --filter web lint` *(fails: `'` can be escaped, parse error)*

------
https://chatgpt.com/codex/tasks/task_e_68ab57dbd7a0832aa9dd0998c4e69e43